### PR TITLE
Prevent new lines in footer links

### DIFF
--- a/less/components/footer.less
+++ b/less/components/footer.less
@@ -104,7 +104,7 @@ footer {
       .footer-links {
         text-align: center;
         a {
-          display: inline;
+          display: inline-block;
         }
       }
     }


### PR DESCRIPTION
Preventing this:
<img width="876" alt="capture d ecran 2017-03-06 a 16 12 31" src="https://cloud.githubusercontent.com/assets/1294206/23618276/c274dcec-0287-11e7-9817-96ae2f90525c.png">
