### PR TITLE
added campaign id switching based on number/locale

### DIFF
--- a/routes/call.js
+++ b/routes/call.js
@@ -43,7 +43,7 @@ module.exports = function handleCallRequest(request, reply) {
   if (!parsed.phone) {
     return reply({
       'call_placed': false,
-      error: `Phone number does not match the format required in ${country}`
+      error: 'Phone number does not match the format required.'
     }).code(409);
   }
 

--- a/routes/call.js
+++ b/routes/call.js
@@ -3,7 +3,8 @@ var FormData = require('form-data');
 var parseNumber = require('libphonenumber-js').parse;
 
 const CALL_POWER_URL = process.env.CALL_POWER_URL;
-const COPYRIGHT_CAMPAIGN_ID = process.env.COPYRIGHT_CAMPAIGN_ID;
+const getCopyrightCampaign = require('./campaign-ids');
+
 
 /**
  * Resolve a locale code back to a country code. For
@@ -23,17 +24,23 @@ function getCorrespondingCountry(locale) {
  * Check whether the provided number is valid for
  * the country it supposedly belongs to.
  */
-function isValidNumber(number, country) {
-  return !!parseNumber(number, country).phone;
+function getParsedNumber(number, country) {
+  if (number.indexOf('+')>-1) {
+    return parseNumber(number);
+  }
+  return parseNumber(number, country);
 }
 
-module.exports = function(request, reply) {
+
+module.exports = function handleCallRequest(request, reply) {
   var callInformation = request.payload;
-  const number = '+' + callInformation.number.replace(/\D/g,'');
-  const country = getCorrespondingCountry(callInformation.locale);
+  const number = callInformation.number.replace(/[^0-9+]/g,'');
+  const locale = callInformation.locale || '';
+  const country = getCorrespondingCountry(locale);
+  const parsed = getParsedNumber(number, country)
 
   // Verify that the number we've been given is a proper number.
-  if (!isValidNumber(number, country)) {
+  if (!parsed.phone) {
     return reply({
       'call_placed': false,
       error: `Phone number does not match the format required in ${country}`
@@ -41,10 +48,11 @@ module.exports = function(request, reply) {
   }
 
   // Set up a call through call-power
+  const cid = getCopyrightCampaign(parsed.country);
   var form = new FormData();
-  form.append('userPhone', number);
-  form.append('userCountry', country);
-  form.append('campaignId', COPYRIGHT_CAMPAIGN_ID);
+  form.append('userPhone', parsed.phone);
+  form.append('userCountry', parsed.country);
+  form.append('campaignId', cid);
 
   fetch(CALL_POWER_URL, { method: 'POST', body: form })
   .then(res => res.json())
@@ -55,6 +63,7 @@ module.exports = function(request, reply) {
     reply({ 'call_placed': true }).code(200);
   })
   .catch(error => {
-    reply({ 'call_placed': false, error: error }).code(409);
+    console.error(`error for ${number}/${locale}/cid:${cid}(${parsed.country}):`, error);
+    reply({ 'call_placed': false, error: error }).code(500);
   });
 };

--- a/routes/campaign-ids.js
+++ b/routes/campaign-ids.js
@@ -3,19 +3,19 @@
  * to be used to resolve the locale to the right campaign.
  */
 const COPYRIGHT_CAMPAIGN_IDS = {
-	'EN': 1, // testing-only campaign id
-    'GB': 2,
-    'FR': 3,
-    'DE': 4,
-    'IT': 5,
-    'PL': 6,
-    'ES': 7
+  'EN': 1, // testing-only campaign id
+  'GB': 2,
+  'FR': 3,
+  'DE': 4,
+  'IT': 5,
+  'PL': 6,
+  'ES': 7
 };
 
 const DEFAULT_CAMPAIGN_ID = 1;
 
 module.exports = function getCopyrightCampaignID(country) {
-    let id = COPYRIGHT_CAMPAIGN_IDS[country];
-    if (!id) return DEFAULT_CAMPAIGN_ID;
-    return id;
+  let id = COPYRIGHT_CAMPAIGN_IDS[country];
+  if (!id) return DEFAULT_CAMPAIGN_ID;
+  return id;
 };

--- a/routes/campaign-ids.js
+++ b/routes/campaign-ids.js
@@ -1,0 +1,21 @@
+/**
+ * This is the mapping for "country" to "campaign id"
+ * to be used to resolve the locale to the right campaign.
+ */
+const COPYRIGHT_CAMPAIGN_IDS = {
+	'EN': 1, // testing-only campaign id
+    'GB': 2,
+    'FR': 3,
+    'DE': 4,
+    'IT': 5,
+    'PL': 6,
+    'ES': 7
+};
+
+const DEFAULT_CAMPAIGN_ID = 1;
+
+module.exports = function getCopyrightCampaignID(country) {
+    let id = COPYRIGHT_CAMPAIGN_IDS[country];
+    if (!id) return DEFAULT_CAMPAIGN_ID;
+    return id;
+};


### PR DESCRIPTION
This PR adds in campaign id switching based on the number the user provided. Note that this is not full coverage, and the fallback ID is 'EN' (which is not a country code and so cannot be accidentally triggered).

For testing this, you probably want to use a "reserver number" for the various places. For instance, for the UK https://www.ofcom.org.uk/phones-telecoms-and-internet/information-for-industry/numbering/numbers-for-drama has the list of "real numbers that are actually fake numbers" for use in film and television. Pretty much every country has a few of these, which are good for testing whether or not things last least go through.

Any campaign that does not have a number hooked up yet will return a 500 error with a JSON response telling you that the campaign id has no numbers.