### PR TITLE
Site title + fixing FB title/desc

### DIFF
--- a/src/lib/react-server-route.js
+++ b/src/lib/react-server-route.js
@@ -37,8 +37,8 @@ function routeFileContent(locales) {
       var localesInfo = [locale];
       var query = queryParser(request.query);
 
-      var fbDesc = messages.sharing_fb_internet_title_a;
-      var fbTitle = messages.sharing_fb_desc_a;
+      var fbDesc = messages.sharing_fb_desc_a;
+      var fbTitle = messages.sharing_fb_internet_title_a;
       var twShare = messages.sharing_twitter_b;
 
       function createElement(Component, props) {

--- a/src/lib/react-server-route.js
+++ b/src/lib/react-server-route.js
@@ -33,7 +33,7 @@ function routeFileContent(locales) {
       var twitterImage = "/assets/images/Copyright-social-01.jpg";
       var facebookImage = "/assets/images/Copyright-social-01.jpg";
       var siteUrl = url.resolve(process.env.APPLICATION_URI, locale + '/');
-            var siteTitle = messages.main_title_digital_age;
+      var siteTitle = messages.main_title_digital_age;
       var localesInfo = [locale];
       var query = queryParser(request.query);
 

--- a/src/lib/react-server-route.js
+++ b/src/lib/react-server-route.js
@@ -32,7 +32,8 @@ function routeFileContent(locales) {
       var favicon = "/assets/images/favicon.png";
       var twitterImage = "/assets/images/Copyright-social-01.jpg";
       var facebookImage = "/assets/images/Copyright-social-01.jpg";
-      var siteUrl = url.resolve(process.env.APPLICATION_URI, locale + '/')
+      var siteUrl = url.resolve(process.env.APPLICATION_URI, locale + '/');
+            var siteTitle = messages.main_title_digital_age;
       var localesInfo = [locale];
       var query = queryParser(request.query);
 
@@ -68,7 +69,7 @@ function routeFileContent(locales) {
             title: ``,
             site_name: 'mozilla.org',
             site_url: siteUrl,
-            site_title: ``,
+            site_title: siteTitle,
             facebook_image: process.env.APPLICATION_URI + facebookImage,
             twitter_image: process.env.APPLICATION_URI + twitterImage
           }}


### PR DESCRIPTION
Adding site title, it will look way better in search engines. Any concern for doing that?
I’ve set `site_title:` which does what I want, not sure what `title:` is supposed to do and if I should set it too?

Also just noticed we inverted the title/description for Facebook sharing (d’oh!)