### PR TITLE
New error strings + description update

### DIFF
--- a/locales/en-US/call_tool.properties
+++ b/locales/en-US/call_tool.properties
@@ -30,5 +30,5 @@ try_again=TRY AGAIN
 we_cannot_call=We can’t call that number. Please choose a country code from the list.
 hourly_limit_reached=Thanks for your calls! You’ve reached the hourly limit. Please try again in an hour.
 closed_for_business=Please visit this page during business hours to connect your call:
-business_hours_cest=Monday-Friday, 9:00-18:00 CEST
-business_hours_cet=Monday-Friday, 9:00-18:00 CET
+business_hours_cest=Monday-Friday, 9:00-18:00 CEST.
+business_hours_cet=Monday-Friday, 9:00-18:00 CET.

--- a/locales/en-US/call_tool.properties
+++ b/locales/en-US/call_tool.properties
@@ -27,3 +27,5 @@ whoops_phone_number=Whoops! Make sure you enter your correct phone number.
 unknown_problems=We’re sorry, we seem to be having some trouble.
 please_retry_later=Please try again later.
 try_again=TRY AGAIN
+we_cannot_call=We can’t call that number. Please choose a country code from the list.
+hourly_limit_reached=Thanks for your calls! You’ve reached the hourly limit. Please try again in an hour.

--- a/locales/en-US/call_tool.properties
+++ b/locales/en-US/call_tool.properties
@@ -30,4 +30,5 @@ try_again=TRY AGAIN
 we_cannot_call=We can’t call that number. Please choose a country code from the list.
 hourly_limit_reached=Thanks for your calls! You’ve reached the hourly limit. Please try again in an hour.
 closed_for_business=Please note, calling is only available during business hours:
-business_hours=Monday-Friday, 9:00-18:00 CEST
+business_hours_cest=Monday-Friday, 9:00-18:00 CEST
+business_hours_cet=Monday-Friday, 9:00-18:00 CET

--- a/locales/en-US/call_tool.properties
+++ b/locales/en-US/call_tool.properties
@@ -29,6 +29,6 @@ please_retry_later=Please try again later.
 try_again=TRY AGAIN
 we_cannot_call=We can’t call that number. Please choose a country code from the list.
 hourly_limit_reached=Thanks for your calls! You’ve reached the hourly limit. Please try again in an hour.
-closed_for_business=Please note, calling is only available during business hours:
+closed_for_business=Please visit this page during business hours to connect your call:
 business_hours_cest=Monday-Friday, 9:00-18:00 CEST
 business_hours_cet=Monday-Friday, 9:00-18:00 CET

--- a/locales/en-US/call_tool.properties
+++ b/locales/en-US/call_tool.properties
@@ -29,3 +29,4 @@ please_retry_later=Please try again later.
 try_again=TRY AGAIN
 we_cannot_call=We can’t call that number. Please choose a country code from the list.
 hourly_limit_reached=Thanks for your calls! You’ve reached the hourly limit. Please try again in an hour.
+closed_for_business=Please note, calling is only available during business hours (Monday-Friday, 9:00-18:00 CEST.)

--- a/locales/en-US/call_tool.properties
+++ b/locales/en-US/call_tool.properties
@@ -29,4 +29,5 @@ please_retry_later=Please try again later.
 try_again=TRY AGAIN
 we_cannot_call=We can’t call that number. Please choose a country code from the list.
 hourly_limit_reached=Thanks for your calls! You’ve reached the hourly limit. Please try again in an hour.
-closed_for_business=Please note, calling is only available during business hours (Monday-Friday, 9:00-18:00 CEST.)
+closed_for_business=Please note, calling is only available during business hours:
+business_hours=Monday-Friday, 9:00-18:00 CEST

--- a/locales/en-US/copyright.properties
+++ b/locales/en-US/copyright.properties
@@ -7,6 +7,7 @@ nav_call_now=Call Now
 main_title_digital_age=Stand Up for Copyright in the Digital Age
 epic_battle_tagline_mep=Members of the European Parliament need to hear from you.
 main_title_desc_september=Call Members of the European Parliament before 10 October, tell them we need copyright laws that promote competition & innovation online.
+main_title_desc=Call Members of the European Parliament, tell them we need copyright laws that promote competition & innovation online.
 
 # Call to action
 call_now_button=CALL NOW

--- a/locales/fr/copyright.properties
+++ b/locales/fr/copyright.properties
@@ -7,6 +7,7 @@ nav_call_now=Appeler un député
 main_title_digital_age=Mobilisez-vous pour le droit d’auteur à l’ère du numérique
 epic_battle_tagline_mep=Faites-vous entendre auprès des députés européens.
 main_title_desc_september=Appelez les députés européens avant le 10 octobre et faites-leur savoir que la règlementation sur le droit d’auteur doit promouvoir la concurrence et l’innovation en ligne.
+main_title_desc=Appelez les députés européens et faites-leur savoir que la règlementation sur le droit d’auteur doit promouvoir la concurrence et l’innovation en ligne.
 
 # Call to action
 call_now_button=APPELER MAINTENANT

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -6,11 +6,15 @@ module.exports = React.createClass({
     intl: React.PropTypes.object
   },
   render: function() {
+    var title = 'main_title_desc_september';
+    if (/^(en|fr)(\b|$)/.test(this.context.intl.locale)) {
+      title = 'main_title_desc';
+    }
     return (
       <header className="header">
         <h1>{this.context.intl.formatMessage({id: 'main_title_digital_age'})}</h1>
         <p><span className="blue-highlight">{this.context.intl.formatMessage({id: 'epic_battle_tagline_mep'})}</span></p>
-        <p className="header-paragraph">{this.context.intl.formatMessage({id: 'main_title_desc_september'})}</p>
+        <p className="header-paragraph">{this.context.intl.formatMessage({id: title})}</p>
         <CallButton shadow={true} />
         <p className="italic"><a href={`/${this.context.intl.locale}/call-now`}>{this.context.intl.formatMessage({id: 'cta_tagline_calling'})}</a></p>
       </header>


### PR DESCRIPTION
@ScottDowne wouldn’t mind a quick look from you on the string fallback if you’re around. Looks pretty safe and works locally, but I prefer not to mess it up.

What it’s supposed to do:
- Use main_title_desc for English and French, since the strings are ready.
- Keep using main_title_desc_september with the wrong date until we have the translations.